### PR TITLE
fix read property 'input' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,9 @@ Assets.prototype.postcss = function (css) {
   css.eachDecl(function (decl) {
 
     // Store the input file path of the file being processed
-    self.inputPath = decl.source.input.file;
+    if (decl.source && decl.source.input && decl.source.input.file) {
+      self.inputPath = decl.source.input.file;
+    }
 
     try {
 


### PR DESCRIPTION
```
TypeError: Cannot read property 'input' of undefined
    at /app/node_modules/postcss-assets/index.js:222:33
    at /app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:88:34
    at /app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:73:26
    at AtRule.each (/app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:59:22)
    at AtRule.walk (/app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:72:21)
    at /app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:76:32
    at Root.each (/app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:59:22)
    at Root.walk (/app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:72:21)
    at Root.walkDecls (/app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:86:25)
    at Root.eachDecl (/app/node_modules/gulp-postcss/node_modules/postcss/lib/container.js:494:21)

```
